### PR TITLE
[Feature] Protect authentication controller with roles policies

### DIFF
--- a/RestaurantSimulation.Angular.Frontend/RestaurantSimulation.Frontend/src/app/app.component.html
+++ b/RestaurantSimulation.Angular.Frontend/RestaurantSimulation.Frontend/src/app/app.component.html
@@ -9,6 +9,9 @@
     <button (click)="getAccessToken()">
         Get access token
     </button>
+    <button (click)="getRoles()">
+        Get Roles
+    </button>
 </ng-container>
 <ng-template #loggedOut>
     <button (click)="auth.loginWithRedirect()">Log in</button>

--- a/RestaurantSimulation.Angular.Frontend/RestaurantSimulation.Frontend/src/app/app.component.ts
+++ b/RestaurantSimulation.Angular.Frontend/RestaurantSimulation.Frontend/src/app/app.component.ts
@@ -25,7 +25,13 @@ export class AppComponent {
   }
 
   getAccessToken() {
-    console.log(this.auth.getAccessTokenSilently().subscribe((token) => {
+    console.log(this.auth.getAccessTokenSilently({ ignoreCache: true }).subscribe((token) => {
+      console.log(token);
+    }));
+  }
+
+  getRoles() {
+    console.log(this.auth.getIdTokenClaims().subscribe((token) => {
       console.log(token);
     }));
   }

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Api/Controllers/AuthenticationController.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Api/Controllers/AuthenticationController.cs
@@ -9,11 +9,11 @@ using RestaurantSimulation.Application.Authentication.Queries.GetUserByAccessTok
 using RestaurantSimulation.Application.Authentication.Queries.GetUserById;
 using RestaurantSimulation.Application.Authentication.Queries.GetUsers;
 using RestaurantSimulation.Contracts.Authentication;
+using RestaurantSimulation.Domain.Common.Policies.Authorization;
 
 namespace RestaurantSimulation.Api.Controllers
 {
     [Route("api/auth")]
-    [Authorize]
     public class AuthenticationController : ApiController
     {
         private readonly ISender _sender;
@@ -27,6 +27,7 @@ namespace RestaurantSimulation.Api.Controllers
             _extractUserClaimsService = extractUserClaimsService;
         }
 
+        [Authorize(Policy = AuthorizationPolicies.ClientOrAdminRolePolicy)]
         [HttpPost("users/register")]
         public async Task<IActionResult> Register(RegisterRequest request)
         {
@@ -55,6 +56,7 @@ namespace RestaurantSimulation.Api.Controllers
                 errors => Problem(errors));
         }
 
+        [Authorize(Policy = AuthorizationPolicies.ClientOrAdminRolePolicy)]
         [HttpGet("users/accesstoken")]
         public async Task<IActionResult> GetUserByAccessToken()
         {
@@ -65,6 +67,7 @@ namespace RestaurantSimulation.Api.Controllers
                 errors => Problem(errors));
         }
 
+        [Authorize(Policy = AuthorizationPolicies.ClientOrAdminRolePolicy)]
         [HttpGet("users/id/{id}")]
         public async Task<IActionResult> GetUserById(Guid id)
         {
@@ -75,6 +78,7 @@ namespace RestaurantSimulation.Api.Controllers
                 errors => Problem(errors));
         }
 
+        [Authorize(Policy = AuthorizationPolicies.AdminRolePolicy)]
         [HttpGet("users")]
         public async Task<IActionResult> GetUsers()
         {

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Claims/RestaurantSimulationClaims.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Claims/RestaurantSimulationClaims.cs
@@ -1,0 +1,7 @@
+﻿namespace RestaurantSimulation.Domain.Common.Claims
+{
+    public class RestaurantSimulationClaims
+    {
+        public const string RestaurantSimulationRoles = "restaurant-simulation-roles";
+    }
+}

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Policies/Authorization/AuthorizationPolicies.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Policies/Authorization/AuthorizationPolicies.cs
@@ -1,0 +1,11 @@
+﻿namespace RestaurantSimulation.Domain.Common.Policies.Authorization
+{
+    public class AuthorizationPolicies
+    {
+        public const string AdminRolePolicy = "AdminRolePolicy";
+
+        public const string ClientRolePolicy = "ClientRolePolicy";
+
+        public const string ClientOrAdminRolePolicy = "ClientOrAdminRolePolicy";
+    }
+}

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Roles/RestaurantSimulationRoles.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Domain/Common/Roles/RestaurantSimulationRoles.cs
@@ -1,0 +1,9 @@
+﻿namespace RestaurantSimulation.Domain.Common.Roles
+{
+    public class RestaurantSimulationRoles
+    {
+        public const string AdminRole = "restaurant-simulation-admin";
+
+        public const string ClientRole = "restaurant-simulation-client";
+    }
+}

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Infrastructure/DependencyInjection.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Infrastructure/DependencyInjection.cs
@@ -7,6 +7,9 @@ using RestaurantSimulation.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using RestaurantSimulation.Application.Common.Interfaces.Persistence;
 using RestaurantSimulation.Infrastructure.Persistence.Authentication;
+using RestaurantSimulation.Domain.Common.Policies.Authorization;
+using RestaurantSimulation.Domain.Common.Claims;
+using RestaurantSimulation.Domain.Common.Roles;
 
 namespace RestaurantSimulation.Infrastructure
 {
@@ -15,6 +18,7 @@ namespace RestaurantSimulation.Infrastructure
         public static IServiceCollection AddInfrastructure(this IServiceCollection services, ConfigurationManager configuration)
         {
             services.AddAuthenticationServices(configuration)
+                .AddAuthorizationServices(configuration)
                 .AddPersistenceServices(configuration);
 
             return services;
@@ -34,6 +38,31 @@ namespace RestaurantSimulation.Infrastructure
                         NameClaimType = ClaimTypes.NameIdentifier
                     };
                 });
+
+
+            return services;
+        }
+
+        public static IServiceCollection AddAuthorizationServices(this IServiceCollection services, ConfigurationManager configuration)
+        {
+            services.AddAuthorization(options =>
+            {
+                options.AddPolicy(AuthorizationPolicies.AdminRolePolicy,
+                    (policy) => {
+                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.AdminRole);
+                    });
+
+                options.AddPolicy(AuthorizationPolicies.ClientRolePolicy,
+                    (policy) => {
+                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.ClientRole);
+                    });
+
+                options.AddPolicy(AuthorizationPolicies.ClientOrAdminRolePolicy,
+                    (policy) => {
+                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.ClientRole, RestaurantSimulationRoles.AdminRole);
+                    });
+
+            });
 
             return services;
         }

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/Authentication/AuthenticationControllerTests.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/Authentication/AuthenticationControllerTests.cs
@@ -1,5 +1,6 @@
 ﻿using RestaurantSimulation.Application.Authentication.Common;
 using RestaurantSimulation.Contracts.Authentication;
+using RestaurantSimulation.Domain.Common.Roles;
 using Shouldly;
 using System.Net;
 using System.Net.Http.Json;
@@ -11,13 +12,13 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Add_A_New_User()
         {
-            await AuthenticateAndRegisterAUser();
+            await AuthenticateAndRegisterClientUser();
         }
 
         [Fact]
         public async Task Should_Get_A_List_Of_Users()
         {
-            await AuthenticateAndRegisterAUser();
+            await AuthenticateAndRegisterAdminUser();
 
             var responseGet = await TestClient.GetAsync("/api/auth/users/");
 
@@ -32,7 +33,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Get_User_By_Access_Token()
         {
-            await AuthenticateAndRegisterAUser();
+            await AuthenticateAndRegisterClientUser();
 
             var responseGet = await TestClient.GetAsync("/api/auth/users/accesstoken");
 
@@ -47,7 +48,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Not_Found_When_User_Is_Not_Registered_Getting_By_Access_Token()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responseGet = await TestClient.GetAsync("/api/auth/users/accesstoken");
 
@@ -57,7 +58,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Not_Found_If_A_User_With_Specified_Id_Not_Registered()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responseGet = await TestClient.GetAsync($"/api/auth/users/id/{Guid.NewGuid()}");
 
@@ -68,7 +69,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_User_Registered_With_Specified_Id()
         {
-            await AuthenticateAndRegisterAUser();
+            await AuthenticateAndRegisterAdminUser();
 
             var responseGet = await TestClient.GetAsync("/api/auth/users/");
 
@@ -91,7 +92,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Bad_Request_If_Validations_For_First_Name_Will_Fail()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
                 CreateRegisterRequest("", "Doctorul", "0773823901", "Piatra Neamt"));
@@ -112,7 +113,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Bad_Request_If_Validations_For_Last_Name_Will_Fail()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
                 CreateRegisterRequest("Mirel", "", "0773823901", "Piatra Neamt"));
@@ -133,7 +134,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Bad_Request_If_Validations_For_PhoneNumber_Will_Fail()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
                 CreateRegisterRequest("Mirel", "Dorel", "07738239011", "Piatra Neamt"));
@@ -154,7 +155,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Bad_Request_If_Validations_For_Address_Will_Fail()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
 
             var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
                 CreateRegisterRequest("Mirel", "Dorel", "0773823901", "%#$heh^^"));
@@ -171,9 +172,19 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         /**************/
         /***HELPERS****/
         /*************/
-        public async Task AuthenticateAndRegisterAUser()
+        public async Task AuthenticateAndRegisterClientUser()
         {
-            AuthenticateAsync();
+            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
+
+            var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
+                CreateRegisterRequest("Mirel", "Doctorul", "0773823901", "Piatra Neamt"));
+
+            responsePost.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        public async Task AuthenticateAndRegisterAdminUser()
+        {
+            AuthenticateAsync(RestaurantSimulationRoles.AdminRole);
 
             var responsePost = await TestClient.PostAsJsonAsync("/api/auth/users/register",
                 CreateRegisterRequest("Mirel", "Doctorul", "0773823901", "Piatra Neamt"));

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/IntegrationTests.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/IntegrationTests.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using RestaurantSimulation.Domain.Common.Claims;
+using RestaurantSimulation.Domain.Common.Roles;
 using RestaurantSimulation.Infrastructure.Persistence;
 using System.Dynamic;
 using System.Net;
@@ -45,12 +47,13 @@ namespace RestaurantSimulation.Tests.IntegrationTests
             TestClient = appFactory.CreateClient();
         }
 
-        protected void  AuthenticateAsync()
+        protected void  AuthenticateAsync(string role)
         {
             var data = new ExpandoObject() as IDictionary<string, Object>;
 
             data.Add(ClaimTypes.NameIdentifier, Guid.NewGuid());
             data.Add(ClaimTypes.Email, $"test_mail{Guid.NewGuid()}@restaurant.com");
+            data.Add(RestaurantSimulationClaims.RestaurantSimulationRoles, role);
 
             TestClient.SetFakeBearerToken((object)data);
         }


### PR DESCRIPTION
- Protect the authentication controller with roles policies.
- Roles are added into Auth0 Provider.
- Update tests to work with the new Roles.
- /users route can be used only by **Restaurant Simulation Admins**.
- Authentication controller functionality is visible to Restaurant Simulation Admins too.