### PR TITLE
[Feature] GetUserById can be called only by Admins

### DIFF
--- a/RestaurantSimulation.Backend/RestaurantSimulation.Api/Controllers/AuthenticationController.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Api/Controllers/AuthenticationController.cs
@@ -67,7 +67,7 @@ namespace RestaurantSimulation.Api.Controllers
                 errors => Problem(errors));
         }
 
-        [Authorize(Policy = AuthorizationPolicies.ClientOrAdminRolePolicy)]
+        [Authorize(Policy = AuthorizationPolicies.AdminRolePolicy)]
         [HttpGet("users/id/{id}")]
         public async Task<IActionResult> GetUserById(Guid id)
         {

--- a/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/Authentication/AuthenticationControllerTests.cs
+++ b/RestaurantSimulation.Backend/RestaurantSimulation.Tests/IntegrationTests/Authentication/AuthenticationControllerTests.cs
@@ -58,7 +58,7 @@ namespace RestaurantSimulation.Tests.IntegrationTests.Authentication
         [Fact]
         public async Task Should_Return_Not_Found_If_A_User_With_Specified_Id_Not_Registered()
         {
-            AuthenticateAsync(RestaurantSimulationRoles.ClientRole);
+            AuthenticateAsync(RestaurantSimulationRoles.AdminRole);
 
             var responseGet = await TestClient.GetAsync($"/api/auth/users/id/{Guid.NewGuid()}");
 


### PR DESCRIPTION
- Protect **/users/id/{id}** api route to be called only by the Users that have the Admin role
- Modify Integration Tests to work, with the new modification