### PR TITLE
Removed unused formatting

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,14 +5,10 @@ on:
     branches: '**'
     paths:
     - 'RestaurantSimulation.Backend/**'               # target all the changes for backend
-    - '!RestaurantSimulation.Angular.Frontend/**'     # ignore everything related to frontend
-    - '!RestaurantSimulation.Next.Frontend/**'        # ignore everything related to frontend
   pull_request:
     branches: [main]
     paths:
     - 'RestaurantSimulation.Backend/**'               # target all the changes for backend
-    - '!RestaurantSimulation.Angular.Frontend/**'     # ignore everything related to frontend
-    - '!RestaurantSimulation.Next.Frontend/**'        # ignore everything related to frontend
 
 env:
   DOTNET_VERSION: "6.0.x"


### PR DESCRIPTION
These are not required, as paths only run as Github Docs says: "if at least one path matches a pattern in the paths filter, the workflow runs". Example of using both including & excluding paths:
    paths:
      - 'sub-project/**'
      - '!sub-project/docs/**'