### PR TITLE
[Backend bug] Use custom claim name for email address

### DIFF
--- a/RestaurantSimulation.Backend/src/RestaurantSimulation.Application/Authentication/Common/Services/ExtractUserClaims/ExtractUserClaimsService.cs
+++ b/RestaurantSimulation.Backend/src/RestaurantSimulation.Application/Authentication/Common/Services/ExtractUserClaims/ExtractUserClaimsService.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using ErrorOr;
 using RestaurantSimulation.Domain.RestaurantApplicationErrors;
 using Microsoft.Extensions.Logging;
+using RestaurantSimulation.Domain.Common.Claims;
 
 namespace RestaurantSimulation.Application.Authentication.Common.Services.ExtractUserClaims
 {
@@ -27,7 +28,7 @@ namespace RestaurantSimulation.Application.Authentication.Common.Services.Extrac
 
         public ErrorOr<string> GetUserEmail()
         {
-            Claim email = GetClaimsIdentity()?.Claims.FirstOrDefault(x => x.Type == ClaimTypes.Email);
+            Claim email = GetClaimsIdentity()?.Claims.FirstOrDefault(x => x.Type == RestaurantSimulationClaims.Email);
 
             if (email is null)
             {

--- a/RestaurantSimulation.Backend/src/RestaurantSimulation.Domain/Common/Claims/RestaurantSimulationClaims.cs
+++ b/RestaurantSimulation.Backend/src/RestaurantSimulation.Domain/Common/Claims/RestaurantSimulationClaims.cs
@@ -2,6 +2,8 @@
 {
     public class RestaurantSimulationClaims
     {
-        public const string RestaurantSimulationRoles = "restaurant-simulation-roles";
+        public const string Roles = "restaurant-simulation-roles";
+
+        public const string Email = "restaurant-simulation-email";
     }
 }

--- a/RestaurantSimulation.Backend/src/RestaurantSimulation.Infrastructure/DependencyInjection.cs
+++ b/RestaurantSimulation.Backend/src/RestaurantSimulation.Infrastructure/DependencyInjection.cs
@@ -51,17 +51,17 @@ namespace RestaurantSimulation.Infrastructure
             {
                 options.AddPolicy(AuthorizationPolicies.AdminRolePolicy,
                     (policy) => {
-                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.AdminRole);
+                        policy.RequireClaim(RestaurantSimulationClaims.Roles, RestaurantSimulationRoles.AdminRole);
                     });
 
                 options.AddPolicy(AuthorizationPolicies.ClientRolePolicy,
                     (policy) => {
-                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.ClientRole);
+                        policy.RequireClaim(RestaurantSimulationClaims.Roles, RestaurantSimulationRoles.ClientRole);
                     });
 
                 options.AddPolicy(AuthorizationPolicies.ClientOrAdminRolePolicy,
                     (policy) => {
-                        policy.RequireClaim(RestaurantSimulationClaims.RestaurantSimulationRoles, RestaurantSimulationRoles.ClientRole, RestaurantSimulationRoles.AdminRole);
+                        policy.RequireClaim(RestaurantSimulationClaims.Roles, RestaurantSimulationRoles.ClientRole, RestaurantSimulationRoles.AdminRole);
                     });
 
             });

--- a/RestaurantSimulation.Backend/tests/RestaurantSimulation.IntegrationTests/Helpers/CustomWebApplicationBase.cs
+++ b/RestaurantSimulation.Backend/tests/RestaurantSimulation.IntegrationTests/Helpers/CustomWebApplicationBase.cs
@@ -63,8 +63,8 @@ namespace RestaurantSimulation.IntegrationTests.Helpers
             var data = new ExpandoObject() as IDictionary<string, Object>;
 
             data.Add(ClaimTypes.NameIdentifier, userSub);
-            data.Add(ClaimTypes.Email, email);
-            data.Add(RestaurantSimulationClaims.RestaurantSimulationRoles, role);
+            data.Add(RestaurantSimulationClaims.Email, email);
+            data.Add(RestaurantSimulationClaims.Roles, role);
 
             _httpClient.SetFakeBearerToken((object)data);
         }


### PR DESCRIPTION
- `restaurant-simulation-email` claim contains the email address of the current logged user in Auth0